### PR TITLE
Fix cmtk wrapper script help

### DIFF
--- a/core/scripts/cmtk.in
+++ b/core/scripts/cmtk.in
@@ -52,8 +52,8 @@ else
     export LD_LIBRARY_PATH=${CMTK_LIBRARY_DIR}
 fi
 
-if echo "$CMD $@" | grep -q -e --help; then
-    [ "$CMD" = "--help" ] && man cmtk || man <( cmtk-${CMDPATH} --man )
+if [ -z "$@" ] || [ "$@" = "--help" ] ; then
+    ${CMDPATH} "--help"
 else
     ${CMDPATH} "$@"
 fi


### PR DESCRIPTION
- The man pages don't come with current binary distributions on mac
- and lookup fails anyway for commands
- and I've never seen a generic cmtk man page
