### PR TITLE
Fix for missing finite function

### DIFF
--- a/core/cmtkconfig.h.cmake
+++ b/core/cmtkconfig.h.cmake
@@ -189,6 +189,11 @@ inline int finite( const double x ) { return _finite(x); }
 #  define CMTK_PATH_SEPARATOR '/'
 #  define CMTK_PATH_SEPARATOR_STR "/"
 
+#ifndef HAVE_FINITE
+#include <math.h>
+inline int finite( const double x ) { return isfinite(x); }
+#endif // #ifndefHAVE_FINITE
+
 #endif //#ifdef _MSC_VER
 
 #endif // #ifndef __cmtkconfig_h_included__


### PR DESCRIPTION
* causing trouble on macosx local/github builds
* should check if finite if missing
* cmake does this automatically but not sure if changes to CMakeLists are required to make this visible