### PR TITLE
add static cast to make clang happier

### DIFF
--- a/core/apps/vtkxform.cxx
+++ b/core/apps/vtkxform.cxx
@@ -187,7 +187,7 @@ doMain( const int argc, const char* argv[] )
       // Read original point coordinates from file
       if ( binaryMode )
 	{
-	float xyzFloat[3] = { xyz[0], xyz[1], xyz[2] };
+	float xyzFloat[3] = {static_cast<float>(xyz[0]), static_cast<float>(xyz[1]), static_cast<float>(xyz[2])};
 
 #ifndef WORDS_BIGENDIAN
 	for ( size_t i = 0; i<3; ++i )


### PR DESCRIPTION
* it's odd because xyz is defined as a float, or more exactly a  cmtk::FixedVector<3,float> but clang doesn't seem to see it that way